### PR TITLE
REFACTOR - allow for Silverstripe Elemental Grid

### DIFF
--- a/templates/DNADesign/Elemental/Layout/ElementHolder.ss
+++ b/templates/DNADesign/Elemental/Layout/ElementHolder.ss
@@ -1,3 +1,3 @@
-<div class="element $SimpleClassName.LowerCase<% if $StyleVariant %> $StyleVariant<% end_if %><% if $ExtraClass %> $ExtraClass<% end_if %><% if $LinkedElement %> $LinkedElement.$SimpleClassName.LowerCase<% end_if %> mb-4" id="$Anchor">
+<div class="element $Element.ColumnClasses $SimpleClassName.LowerCase<% if $StyleVariant %> $StyleVariant<% end_if %><% if $ExtraClass %> $ExtraClass<% end_if %> mb-4" id="$Anchor">
     $Element
 </div>

--- a/templates/Dynamic/Base/Page/CampaignLandingPage.ss
+++ b/templates/Dynamic/Base/Page/CampaignLandingPage.ss
@@ -5,41 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     $MetaTags(false)
 
-    <title><% if $PageTitle %>$PageTitle<% else %>$Title &#124; $SiteConfig.CompanyName<% end_if %></title>
+    <title><% if $PageTitle %>$PageTitle<% else %>$Title &#124; $SiteConfig.Title<% end_if %></title>
 
     <% include Favicons %>
-
-    <% if $ClassName.ShortName = Blog %>
-        <link rel="canonical" href="$AbsoluteLink" />
-    <% end_if %>
-
-    <% require themedCSS("dist/css/app") %>
-
+    <% if $ClassName.ShortName = Blog %><link rel="canonical" href="$AbsoluteLink" /><% end_if %>
+    <% include Requirements %>
     <% include FontKit %>
-
-    <% include Analytics %>
-
     <% include CustomStyles %>
+    <% include Innoweb/GoogleAnalytics/GoogleAnalyticsHead %>
 </head>
-<body class="$ClassName loading">
+<body class="$ClassName.ShortName">
 
-    <% include AnalyticsBody %>
+    <% include Innoweb/GoogleAnalytics/GoogleAnalyticsBody %>
 
     <main role="main">
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-12">
-                    <div class="element-area main-element-area">
-                        $ElementalArea
-                    </div>
-                </div>
-            </div>
+        <div class="element-area main-element-area">
+            $ElementalArea
         </div>
     </main>
 
     $BetterNavigator
-
-    <% include HubspotIntegration %>
-
 </body>
 </html>

--- a/templates/Dynamic/Base/Page/Layout/BlockPage.ss
+++ b/templates/Dynamic/Base/Page/Layout/BlockPage.ss
@@ -1,10 +1,12 @@
-<div class="row">
-    <div class="col-md-12 mb-3">
-        $Breadcrumbs(20, false, false, true)
-        <h1>$Title</h1>
-        <% if $Content %><div class="typography mb-4">$Content</div><% end_if %>
-        <div class="element-area main-element-area">
-            $ElementalArea
+<div class="container">
+    <div class="row">
+        <div class="col-md-12 mb-3">
+            $Breadcrumbs(20, false, false, true)
+            <h1>$Title</h1>
+            <% if $Content %><div class="typography mb-4">$Content</div><% end_if %>
         </div>
     </div>
+</div>
+<div class="element-area main-element-area">
+    $ElementalArea
 </div>

--- a/templates/Dynamic/Base/Page/Layout/HomePage.ss
+++ b/templates/Dynamic/Base/Page/Layout/HomePage.ss
@@ -1,12 +1,3 @@
-<div class="row">
-    <div class="col-md-12 mb-5">
-        $ElementalHomePage
-    </div>
+<div class="element-area main-element-area">
+    $ElementalHomePage
 </div>
-<div class="row">
-    <div class="col-md-12 mb-5">
-        $Form
-        $CommentsForm
-    </div>
-</div>
-

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -21,9 +21,7 @@
 
     <main>
         <% include Dynamic/Carousel/Carousel %>
-        <div class="container">
-            $Layout
-        </div>
+        $Layout
     </main>
 
     <% include Footer %>


### PR DESCRIPTION
* Page.ss - remove container wrapper around $Layout so $ElementalArea in a layout can be full width

* ElementHolder.ss - update to add `$Element.ColumnClasses` for Grid. Remove legacy `$LinkedElement` as VIrtualBlock has its own layout now

* BlockPage.ss - add container around $Title/$Content, don't wrap the $ElementalArea in a container

* HomePage.ss - remove row and col wrapper from $ElementalHomePage to allow full-width blocks

* CampaignLandingPage.ss - sync up with prior changes made to Page.ss